### PR TITLE
remove plan from e2e

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -33,8 +33,6 @@ jobs:
         with_wrapper: false
     - name: Terraform Init
       run: cd examples/basic && terraform init -upgrade
-    - name: Terraform Plan
-      run: cd examples/basic && terraform init -upgrade && terraform plan
 
   terratest:
     name: 'Terratest'


### PR DESCRIPTION
The plan requires an ssh key now, and is covered in the terratest