### PR TITLE
fix: ingress to load balancer

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711715736,
-        "narHash": "sha256-9slQ609YqT9bT/MNX9+5k5jltL9zgpn36DpFB7TkttM=",
+        "lastModified": 1712192574,
+        "narHash": "sha256-LbbVOliJKTF4Zl2b9salumvdMXuQBr2kuKP5+ZwbYq4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "807c549feabce7eddbf259dbdcec9e0600a0660d",
+        "rev": "f480f9d09e4b4cf87ee6151eba068197125714de",
         "type": "github"
       },
       "original": {

--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,8 @@ locals {
   domain_zone = var.domain_zone
 
   # load balancer
-  load_balancer_name = var.load_balancer_name
+  load_balancer_name         = var.load_balancer_name
+  load_balancer_access_cidrs = var.load_balancer_access_cidrs
 }
 
 data "aws_availability_zones" "available" {
@@ -119,8 +120,10 @@ module "network_load_balancer" {
   source            = "./modules/network_load_balancer"
   use               = local.load_balancer_use_strategy
   name              = local.load_balancer_name
+  vpc_id            = module.vpc[0].id
   security_group_id = module.security_group[0].id
   subnet_ids        = [for subnet in module.subnet : subnet.id]
+  access_cidrs      = local.load_balancer_access_cidrs
 }
 
 module "domain" {

--- a/modules/network_load_balancer/main.tf
+++ b/modules/network_load_balancer/main.tf
@@ -1,8 +1,10 @@
 locals {
   use               = var.use
   name              = var.name
+  vpc_id            = var.vpc_id
   security_group_id = var.security_group_id
   subnet_ids        = var.subnet_ids
+  access_cidrs      = var.access_cidrs
   create            = (local.use == "create" ? 1 : 0)
   select            = (local.use == "select" ? 1 : 0)
 
@@ -24,10 +26,29 @@ data "aws_eip" "selected" {
   }
 }
 
-
 resource "aws_eip" "created" {
   count  = local.create
   domain = "vpc"
+}
+
+resource "aws_security_group" "load_balancer" {
+  count       = local.create
+  name        = "${local.name}-lb"
+  description = "Security group for load balancer ${local.name}"
+  vpc_id      = local.vpc_id
+  tags = {
+    Name = local.name
+  }
+}
+
+resource "aws_security_group_rule" "external_ingress" {
+  for_each          = (local.create == 1 ? local.access_cidrs : {})
+  security_group_id = aws_security_group.load_balancer[0].id
+  type              = "ingress"
+  from_port         = each.key
+  to_port           = each.key
+  protocol          = "-1"
+  cidr_blocks       = each.value
 }
 
 resource "aws_lb" "new" {

--- a/modules/network_load_balancer/variables.tf
+++ b/modules/network_load_balancer/variables.tf
@@ -17,6 +17,12 @@ variable "name" {
     This tag is how we will find it again in the future.
   EOT
 }
+variable "vpc_id" {
+  type        = string
+  description = <<-EOT
+    The VPC id where the load balancer will be created.
+  EOT
+}
 variable "security_group_id" {
   type        = string
   description = <<-EOT
@@ -30,4 +36,13 @@ variable "subnet_ids" {
     The subnet ids to attach to the Load Balancer.
   EOT
   default     = []
+}
+variable "access_cidrs" {
+  type        = map(list(string))
+  description = <<-EOT
+    A list of maps relating a port to a list of CIDRs that are allowed to access the load balancer external to the VPC.
+    If this is not provided, no IP addresses will be allowed to access the load balancer externally.
+    example: {"443" = ["1.1.1.1/32"]} would allow IP address 1.1.1.1 to access the load balancer on port 443.
+  EOT
+  default     = {}
 }

--- a/tests/loadbalancer_test.go
+++ b/tests/loadbalancer_test.go
@@ -15,7 +15,7 @@ func TestLoadbalancer(t *testing.T) {
 		uniqueID = random.UniqueId()
 	}
 	directory := "loadbalancer"
-	region := "us-west-1"
+	region := "us-west-2"
 
 	terraformVars := map[string]interface{}{
 		"identifier": uniqueID,

--- a/variables.tf
+++ b/variables.tf
@@ -159,6 +159,15 @@ variable "load_balancer_name" {
   EOT
   default     = ""
 }
+variable "load_balancer_access_cidrs" {
+  type        = map(list(string))
+  description = <<-EOT
+    A list of maps relating a port to a list of CIDRs that are allowed to access the load balancer external to the VPC.
+    If this is not provided, no IP addresses will be allowed to access the load balancer externally.
+    exmaple: [{"443" = ["1.1.1.1/32"]}] would allow IP address 1.1.1.1 to access the load balancer on port 443.
+  EOT
+  default     = {}
+}
 
 # domain
 variable "domain_use_strategy" {


### PR DESCRIPTION
This pull request fixes the issue with ingress to the load balancer. It updates the `main.tf` and `modules/network_load_balancer/main.tf` files to correctly configure the load balancer's access CIDRs. The `load_balancer_access_cidrs` variable is added to the `variables.tf` file to allow specifying a list of CIDRs that are allowed to access the load balancer externally.