### PR TITLE
fix: remove version constraints

### DIFF
--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/cert/versions.tf
+++ b/examples/cert/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/domain/versions.tf
+++ b/examples/domain/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/dualstack/versions.tf
+++ b/examples/dualstack/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/ingress/versions.tf
+++ b/examples/ingress/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/ipv6/versions.tf
+++ b/examples/ipv6/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/loadbalancer/versions.tf
+++ b/examples/loadbalancer/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/securitygroup/versions.tf
+++ b/examples/securitygroup/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/selectsubnets/versions.tf
+++ b/examples/selectsubnets/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/selectvpc/versions.tf
+++ b/examples/selectvpc/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/skipvpc/versions.tf
+++ b/examples/skipvpc/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/vpc/versions.tf
+++ b/examples/vpc/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/modules/domain/main.tf
+++ b/modules/domain/main.tf
@@ -138,7 +138,8 @@ resource "aws_iam_server_certificate" "new" {
   name_prefix       = "${local.content}-"
   certificate_body  = acme_certificate.new[0].certificate_pem
   certificate_chain = acme_certificate.new[0].issuer_pem
-  private_key       = tls_private_key.cert_private_key[0].private_key_pem
+  # full chain: "${acme_certificate.new[0].certificate_pem}${acme_certificate.new[0].issuer_pem}"
+  private_key = tls_private_key.cert_private_key[0].private_key_pem
   lifecycle {
     create_before_destroy = true
   }

--- a/modules/domain/versions.tf
+++ b/modules/domain/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/modules/network_load_balancer/versions.tf
+++ b/modules/network_load_balancer/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/modules/security_group/versions.tf
+++ b/modules/security_group/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/modules/subnet/versions.tf
+++ b/modules/subnet/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
Don't constrain the Terraform version to only use the non BUSL versions.
Users are responsible for how they use our module and whether they are in compliance with their use of Terraform.