### PR TITLE
fix!: remove aws secret, output cert info

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,7 +102,6 @@ jobs:
           IDENTIFIER: ${{github.run_id}}
           ZONE: ${{secrets.ZONE}}
           ACME_SERVER_URL: https://acme-v02.api.letsencrypt.org/directory
-          RANCHER_INSECURE: false
         run: |
           ./run_tests.sh
       - uses: actions/github-script@v7

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -87,13 +87,14 @@ jobs:
           # This format enables automatic generation of changelogs and versioning
           filter() {
             COMMIT="$1"
-            ouput="$(echo "$COMMIT" | grep -e '^fix: ' -e '^feature: ' -e '^feat: ' -e 'refactor!: ' -e 'feature!: ' -e 'feat!: ' -e '^chore(main): ')"
+            output="$(echo "$COMMIT" | grep -e '^fix: ' -e '^feature: ' -e '^feat: ' -e '^refactor!: ' -e '^feature!: ' -e '^feat!: ' -e '^chore(main): ' -e '^Merge branch ')"
             echo "$output"
           }
           prefix_check() {
             message="$1"
-            if [ "" != "$(filter "$message")" ]; then
-              echo "...Commit message does not start with the required prefix.
+            if [ -z "$(filter "$message")" ]; then
+              echo "
+              ...Commit message does not start with the required prefix.
               Please use one of the following prefixes: fix:, feature:, feat:, refactor!:, feature!:, feat:!.
               'chore(main): ' is also allowed for release PRs.
               This enables release-please to automatically determine the type of release (major, minor, patch) based on the commit message.
@@ -105,7 +106,7 @@ jobs:
           }
           empty_check() {
             message="$1"
-            if [ "" == "$message" ]; then
+            if [ -z "$message" ]; then
               echo "...Empty commit message."
               exit 1
             else
@@ -123,7 +124,7 @@ jobs:
           }
           spell_check() {
             message="$1"
-            WORDS="$(aspell list <<<"$message")"
+            WORDS="$(aspell list --dont-validate-words <<<"$message")"
             if [ "" != "$WORDS" ]; then
               echo "...Commit message contains spelling errors on: ^$WORDS\$"
               echo "...Also try updating the PR title."
@@ -141,9 +142,9 @@ jobs:
 
           while read -r message; do
             echo "checking message ^$message\$"
-            prefix_check "$message"
             empty_check "$message"
             length_check "$message"
+            prefix_check "$message"
             spell_check "$message"
             echo "message ^$message\$ passed all checks"
           done <<<"$COMMIT_MESSAGES"
@@ -208,3 +209,21 @@ jobs:
             echo "Error: Let's Encrypt CA is not being used for verification."
             exit 1
           fi
+
+  test-compile-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: install-nix
+        run: |
+          curl -L https://nixos.org/nix/install | sh
+          source /home/runner/.nix-profile/etc/profile.d/nix.sh
+          nix --version
+          which nix
+      - name: compile-check
+        shell: /home/runner/.nix-profile/bin/nix develop --ignore-environment --extra-experimental-features nix-command --extra-experimental-features flakes --keep HOME --keep SSH_AUTH_SOCK --keep GITHUB_TOKEN --keep AWS_ROLE --keep AWS_REGION --keep AWS_DEFAULT_REGION --keep AWS_ACCESS_KEY_ID --keep AWS_SECRET_ACCESS_KEY --keep AWS_SESSION_TOKEN --keep UPDATECLI_GPGTOKEN --keep UPDATECLI_GITHUB_TOKEN --keep UPDATECLI_GITHUB_ACTOR --keep GPG_SIGNING_KEY --keep NIX_SSL_CERT_FILE --keep NIX_ENV_LOADED --keep TERM --command bash -e {0}
+        run: |
+          cd test/tests
+          go test -c

--- a/aspell_custom.txt
+++ b/aspell_custom.txt
@@ -1,0 +1,14 @@
+kubernetes
+config
+git
+variablize
+rke2
+rke
+rancher
+oci
+eks
+aks
+readme
+aws
+cert
+info

--- a/examples/basic/outputs.tf
+++ b/examples/basic/outputs.tf
@@ -14,5 +14,6 @@ output "domain" {
   value = module.this.domain
 }
 output "certificate" {
-  value = module.this.certificate
+  value     = module.this.certificate
+  sensitive = true
 }

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.4"
+      version = ">= 2.5"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/cert/outputs.tf
+++ b/examples/cert/outputs.tf
@@ -14,5 +14,6 @@ output "domain" {
   value = module.this.domain
 }
 output "certificate" {
-  value = module.this.certificate
+  value     = module.this.certificate
+  sensitive = true
 }

--- a/examples/cert/versions.tf
+++ b/examples/cert/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.4"
+      version = ">= 2.5"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/domain/outputs.tf
+++ b/examples/domain/outputs.tf
@@ -14,5 +14,6 @@ output "domain" {
   value = module.this.domain
 }
 output "certificate" {
-  value = module.this.certificate
+  value     = module.this.certificate
+  sensitive = true
 }

--- a/examples/domain/versions.tf
+++ b/examples/domain/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.4"
+      version = ">= 2.5"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/dualstack/outputs.tf
+++ b/examples/dualstack/outputs.tf
@@ -14,5 +14,6 @@ output "domain" {
   value = module.this.domain
 }
 output "certificate" {
-  value = module.this.certificate
+  value     = module.this.certificate
+  sensitive = true
 }

--- a/examples/dualstack/versions.tf
+++ b/examples/dualstack/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.4"
+      version = ">= 2.5"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/ingress/outputs.tf
+++ b/examples/ingress/outputs.tf
@@ -17,5 +17,6 @@ output "domain" {
   value = module.this.domain
 }
 output "certificate" {
-  value = module.this.certificate
+  value     = module.this.certificate
+  sensitive = true
 }

--- a/examples/ingress/versions.tf
+++ b/examples/ingress/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.4"
+      version = ">= 2.5"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/ipv6/outputs.tf
+++ b/examples/ipv6/outputs.tf
@@ -14,7 +14,8 @@ output "domain" {
   value = module.this.domain
 }
 output "certificate" {
-  value = module.this.certificate
+  value     = module.this.certificate
+  sensitive = true
 }
 output "subnet_map" {
   value = module.this.subnet_map

--- a/examples/ipv6/versions.tf
+++ b/examples/ipv6/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.4"
+      version = ">= 2.5"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/loadbalancer/outputs.tf
+++ b/examples/loadbalancer/outputs.tf
@@ -14,5 +14,6 @@ output "domain" {
   value = module.this.domain
 }
 output "certificate" {
-  value = module.this.certificate
+  value     = module.this.certificate
+  sensitive = true
 }

--- a/examples/loadbalancer/versions.tf
+++ b/examples/loadbalancer/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.4"
+      version = ">= 2.5"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/securitygroup/outputs.tf
+++ b/examples/securitygroup/outputs.tf
@@ -14,5 +14,6 @@ output "domain" {
   value = module.this.domain
 }
 output "certificate" {
-  value = module.this.certificate
+  value     = module.this.certificate
+  sensitive = true
 }

--- a/examples/securitygroup/versions.tf
+++ b/examples/securitygroup/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.4"
+      version = ">= 2.5"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/selectsubnets/outputs.tf
+++ b/examples/selectsubnets/outputs.tf
@@ -14,5 +14,6 @@ output "domain" {
   value = module.this.domain
 }
 output "certificate" {
-  value = module.this.certificate
+  value     = module.this.certificate
+  sensitive = true
 }

--- a/examples/selectsubnets/versions.tf
+++ b/examples/selectsubnets/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.4"
+      version = ">= 2.5"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/selectvpc/outputs.tf
+++ b/examples/selectvpc/outputs.tf
@@ -14,5 +14,6 @@ output "domain" {
   value = module.this.domain
 }
 output "certificate" {
-  value = module.this.certificate
+  value     = module.this.certificate
+  sensitive = true
 }

--- a/examples/selectvpc/versions.tf
+++ b/examples/selectvpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.4"
+      version = ">= 2.5"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/skipvpc/outputs.tf
+++ b/examples/skipvpc/outputs.tf
@@ -14,5 +14,6 @@ output "domain" {
   value = module.this.domain
 }
 output "certificate" {
-  value = module.this.certificate
+  value     = module.this.certificate
+  sensitive = true
 }

--- a/examples/skipvpc/versions.tf
+++ b/examples/skipvpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.4"
+      version = ">= 2.5"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/examples/vpc/outputs.tf
+++ b/examples/vpc/outputs.tf
@@ -14,5 +14,6 @@ output "domain" {
   value = module.this.domain
 }
 output "certificate" {
-  value = module.this.certificate
+  value     = module.this.certificate
+  sensitive = true
 }

--- a/examples/vpc/versions.tf
+++ b/examples/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.4"
+      version = ">= 2.5"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746397377,
-        "narHash": "sha256-5oLdRa3vWSRbuqPIFFmQBGGUqaYZBxX+GGtN9f/n4lU=",
+        "lastModified": 1753151930,
+        "narHash": "sha256-XSQy6wRKHhRe//iVY5lS/ZpI/Jn6crWI8fQzl647wCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ed30f8aba41605e3ab46421e3dcb4510ec560ff8",
+        "rev": "83e677f31c84212343f4cc553bab85c2efcad60a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,7 @@
           devShells.default = pkgs.mkShell {
             buildInputs = [ devShellPackage ];
             shellHook = ''
+              while read word; do echo -e "*$word\n#" | aspell -a --dont-validate-words >/dev/null; done < aspell_custom.txt
               homebin=$HOME/bin;
               install -d $homebin;
               tfswitch -b $homebin/terraform 1.5.7 &>/dev/null;

--- a/modules/domain/main.tf
+++ b/modules/domain/main.tf
@@ -160,35 +160,3 @@ data "aws_iam_server_certificate" "select" {
   name_prefix = "${local.content}-"
   latest      = true
 }
-
-resource "aws_secretsmanager_secret" "private_key_new" {
-  depends_on = [
-    data.aws_route53_zone.select,
-    aws_route53_record.ipv4,
-    aws_route53_record.ipv6,
-    acme_registration.reg,
-    tls_private_key.private_key,
-    tls_private_key.cert_private_key,
-    tls_cert_request.req,
-    acme_certificate.new,
-  ]
-  count = local.create_cert
-  name  = "${local.content}-private-key"
-}
-
-resource "aws_secretsmanager_secret_version" "private_key_value_new" {
-  depends_on = [
-    data.aws_route53_zone.select,
-    aws_route53_record.ipv4,
-    aws_route53_record.ipv6,
-    acme_registration.reg,
-    tls_private_key.private_key,
-    tls_private_key.cert_private_key,
-    tls_cert_request.req,
-    acme_certificate.new,
-    aws_secretsmanager_secret.private_key_new,
-  ]
-  count         = local.create_cert
-  secret_id     = aws_secretsmanager_secret.private_key_new[0].id
-  secret_string = tls_private_key.cert_private_key[0].private_key_pem
-}

--- a/modules/domain/outputs.tf
+++ b/modules/domain/outputs.tf
@@ -20,30 +20,22 @@ output "zone" {
   value = local.zone_resource
 }
 output "certificate" {
+  sensitive = true
   value = (local.cert_use != "skip" ? (local.select_cert == 1 ? {
-    id          = data.aws_iam_server_certificate.select[0].id
-    arn         = data.aws_iam_server_certificate.select[0].arn
-    name        = data.aws_iam_server_certificate.select[0].name
-    expiration  = data.aws_iam_server_certificate.select[0].expiration_date
-    upload_date = data.aws_iam_server_certificate.select[0].upload_date
-    key_id      = "${local.content}-private-key" # use this to retrieve the private key from AWS with the data aws_secretsmanager_secret_version resource
-    tags_all    = tomap({ "unknown" = "unknown" })
+    # select
+    public_key  = data.aws_iam_server_certificate.select[0].certificate_body
+    private_key = ""
+    chain       = data.aws_iam_server_certificate.select[0].certificate_chain
     } : {
-    id          = aws_iam_server_certificate.new[0].id
-    arn         = aws_iam_server_certificate.new[0].arn
-    name        = aws_iam_server_certificate.new[0].name
-    expiration  = aws_iam_server_certificate.new[0].expiration
-    upload_date = aws_iam_server_certificate.new[0].upload_date
-    key_id      = "${local.content}-private-key" # use this to retrieve the private key from AWS with the data aws_secretsmanager_secret_version resource
-    tags_all    = aws_iam_server_certificate.new[0].tags_all
+    # create
+    public_key  = acme_certificate.new[0].certificate_pem
+    private_key = tls_private_key.cert_private_key[0].private_key_pem
+    chain       = acme_certificate.new[0].issuer_pem
     }) : {
-    id          = ""
-    arn         = ""
-    name        = ""
-    expiration  = ""
-    upload_date = ""
-    key_id      = ""
-    tags_all    = tomap({ "" = "" })
+    # default
+    public_key  = ""
+    private_key = ""
+    chain       = ""
   })
 }
 output "certificate_arn" {

--- a/modules/domain/versions.tf
+++ b/modules/domain/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.4"
+      version = ">= 2.5"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/modules/network_load_balancer/versions.tf
+++ b/modules/network_load_balancer/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.4"
+      version = ">= 2.5"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/modules/security_group/versions.tf
+++ b/modules/security_group/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.4"
+      version = ">= 2.5"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/modules/subnet/versions.tf
+++ b/modules/subnet/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.4"
+      version = ">= 2.5"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.4"
+      version = ">= 2.5"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/outputs.tf
+++ b/outputs.tf
@@ -102,26 +102,19 @@ output "domain" {
 }
 
 output "certificate" {
+  sensitive = true
   value = ((length(module.domain) > 0) ? {
-    id          = module.domain[0].certificate.id
-    arn         = module.domain[0].certificate.arn
-    name        = module.domain[0].certificate.name
-    expiration  = module.domain[0].certificate.expiration
-    upload_date = module.domain[0].certificate.upload_date
-    key_id      = module.domain[0].certificate.key_id
-    tags_all    = module.domain[0].certificate.tags_all
+    private_key = module.domain[0].certificate.private_key
+    public_key  = module.domain[0].certificate.public_key
+    chain       = module.domain[0].certificate.chain
     } : {
     # no object found, but output types are normal
-    id          = ""
-    arn         = ""
-    name        = ""
-    expiration  = ""
-    upload_date = ""
-    key_id      = ""
-    tags_all    = tomap({ "" = "" })
+    private_key = ""
+    public_key  = ""
+    chain       = ""
   })
   description = <<-EOT
-    The certificate object from AWS.
+    The ACME certificate information.
     When generating a domain, a valid TLS certificate is also generated.
     This is helpful for servers and applications to import for securing transfer.
   EOT

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local = {
       source  = "hashicorp/local"
-      version = ">= 2.4"
+      version = ">= 2.5"
     }
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
This PR removes the use of AWS secrets.
It still uses IAM server certificates, but it will output the ACME cert information directly rather than just the IAM certificate information. This changes the output format and forces the output to be sensitive.