### PR TITLE
fix: remove tfswitch and download terraform manually

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -9,3 +9,4 @@ alias tfl='terraform state list'
 alias k='kubectl'
 alias tt='run_tests'
 alias sc='shell_check' # runs shellcheck -x on all files with a shbang
+alias n='nix --extra-experimental-features nix-command --extra-experimental-features flakes'

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ terraform*
 override.*
 *_override.tf
 !terraform.md
+.claude
+.claude/*

--- a/.variables
+++ b/.variables
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+export CHECKPOINT_DISABLE=1
 export TF_IN_AUTOMATION=1
 TF_VAR_ip="$(curl -s 'https://api.ipify.org')"
 if ! [[ "$TF_VAR_ip" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then

--- a/aspell_custom.txt
+++ b/aspell_custom.txt
@@ -38,5 +38,6 @@ rke
 rke2
 sha
 terraform
+tfswitch
 variablize
 yaml

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776225522,
-        "narHash": "sha256-W2npO5nesUm68vECpC3Dl/IOzamvcGAu9uV38hou2yg=",
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "975dad1a84d727dce241bb41b27191948fa5a956",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   outputs = { self, nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachSystem [ "x86_64-darwin" "aarch64-darwin" "x86_64-linux" ]
+    flake-utils.lib.eachSystem [ "aarch64-darwin" "x86_64-linux" "aarch64-linux" ]
       (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
@@ -16,10 +16,6 @@
             "selected" = "v0.70.0";
           };
           leftovers-prep = {
-            "x86_64-darwin" = {
-              "url" = "https://github.com/genevieve/leftovers/releases/download/${leftovers-version.selected}/leftovers-${leftovers-version.selected}-darwin-amd64";
-              "sha" = "sha256-HV12kHqB14lGDm1rh9nD1n7Jvw0rCnxmjC9gusw7jfo=";
-            };
             "aarch64-darwin" = {
               "url" = "https://github.com/genevieve/leftovers/releases/download/${leftovers-version.selected}/leftovers-${leftovers-version.selected}-darwin-arm64";
               "sha" = "sha256-Tw7G538RYZrwIauN7kI68u6aKS4d/0Efh+dirL/kzoM=";
@@ -27,6 +23,11 @@
             "x86_64-linux" = {
               "url" = "https://github.com/genevieve/leftovers/releases/download/${leftovers-version.selected}/leftovers-${leftovers-version.selected}-linux-amd64";
               "sha" = "sha256-D2OPjLlV5xR3f+dVHu0ld6bQajD5Rv9GLCMCk9hXlu8=";
+            };
+            # linux container running on darwin, actual arm linux isnt in the artifacts
+            "aarch64-linux" = {
+              "url" = "https://github.com/genevieve/leftovers/releases/download/${leftovers-version.selected}/leftovers-${leftovers-version.selected}-darwin-arm64";
+              "sha" = "sha256-Tw7G538RYZrwIauN7kI68u6aKS4d/0Efh+dirL/kzoM=";
             };
           };
           leftovers = pkgs.stdenv.mkDerivation {
@@ -40,6 +41,44 @@
               mkdir -p $out/bin
               cp $src $out/bin/leftovers
               chmod +x $out/bin/leftovers
+            '';
+          };
+
+          terraform-version = {
+            "selected" = "1.5.7";
+          };
+          terraform-prep = {
+            "aarch64-darwin" = {
+              "url" = "https://releases.hashicorp.com/terraform/${terraform-version.selected}/terraform_${terraform-version.selected}_darwin_arm64.zip";
+              "sha" = "sha256-23wz6xpEa3OkQ+LFW1MoRfe3DNVhAL7EyW8Vz6tfUMs=";
+              "checksum" = "db7c33eb1a446b73a443e2c55b532845f7b70cd56100bec4c96f15cfab5f50cb";
+            };
+            "x86_64-linux" = {
+              "url" = "https://releases.hashicorp.com/terraform/${terraform-version.selected}/terraform_${terraform-version.selected}_linux_amd64.zip";
+              "sha" = "sha256-wO17wy7lKuJVr5mCyMiKekxhBIXPHVX+6wN+q3X6CCw=";
+              "checksum" = "c0ed7bc32ee52ae255af9982c8c88a7a4c610485cf1d55feeb037eab75fa082c";
+            };
+            # linux container running on darwin or arm linux
+            "aarch64-linux" = {
+              "url" = "https://releases.hashicorp.com/terraform/${terraform-version.selected}/terraform_${terraform-version.selected}_linux_arm64.zip";
+              "sha" = "sha256-9LStfGtgiJYKZn40SVyuSQ+wcpR6n/Jmv1kp9TM1ZeQ=";
+              "checksum" = "f4b4ad7c6b6088960a667e34495cae490fb072947a9ff266bf5929f5333565e4";
+            };
+          };
+          terraform = pkgs.stdenv.mkDerivation {
+            name = "terraform-${terraform-version.selected}";
+            src = pkgs.fetchurl {
+              url = terraform-prep."${system}".url;
+              sha256 = terraform-prep."${system}".sha;
+            };
+            checksum = terraform-prep."${system}".checksum;
+            nativeBuildInputs = [ pkgs.unzip ];
+            phases = [ "installPhase" ];
+            installPhase = ''
+              echo "$checksum  $src" | sha256sum -c -
+              install -d $out/bin
+              unzip -o $src -d $out/bin
+              chmod +x $out/bin/terraform
             '';
           };
           aspellWithDicts = pkgs.aspellWithDicts (d: [d.en d.en-computers]);
@@ -70,9 +109,9 @@
               openssh
               openssl
               shellcheck
+              terraform
               tflint
               tfsec
-              tfswitch
               trivy
               updatecli
               vim
@@ -88,10 +127,6 @@
             buildInputs = [ devShellPackage ];
             shellHook = ''
               while read word; do echo -e "*$word\n#" | aspell -a --dont-validate-words >/dev/null; done < aspell_custom.txt
-              homebin=$HOME/bin;
-              install -d $homebin;
-              tfswitch -b $homebin/terraform 1.5.7 &>/dev/null;
-              export PATH="$homebin:$PATH";
               export PS1="nix:# ";
             '';
           };


### PR DESCRIPTION
<!--- Add labels (eg. release/v14) for each release branch to target --->
<!--- Please don't manually add "internal" labels, those are for automation only --->

## Description
<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
Tools which download Terraform (such as tfswitch) are breaking due to a cert change from Hashicorp/IBM.
This change replaces tfswitch with a manual download of the Terraform version we want, checking against a hard coded checksum of the file.

## Testing
Testing nix would be out of scope for this repo, instead I manually entered the flake.
The CI does this as well, if the CI works then this environment is building properly and working as expected.

<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
