### PR TITLE
fix: ignore subnet mapping and zone id changes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # https://github.com/googleapis/release-please-action
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release-please
         with:
           release-type: terraform-module
@@ -44,7 +44,7 @@ jobs:
           fetch-depth: 0
       - id: aws-creds
         # https://github.com/aws-actions/configure-aws-credentials
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         if: steps.release-please.outputs.pr
         with:
           role-to-assume: ${{env.AWS_ROLE}}

--- a/aspell_custom.txt
+++ b/aspell_custom.txt
@@ -37,6 +37,7 @@ rc
 rke
 rke2
 sha
+subnet
 terraform
 tfswitch
 variablize

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776329215,
-        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "lastModified": 1778458615,
+        "narHash": "sha256-cY07EsdhBJ8tFXPzDYevgqxRev9ZLxFonuq9wmq5kwg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "rev": "c6e5ca3c836a5f4dd9af9f2c1fc1c38f0fac988a",
         "type": "github"
       },
       "original": {

--- a/modules/domain/main.tf
+++ b/modules/domain/main.tf
@@ -45,6 +45,7 @@ resource "aws_route53_record" "ipv4" {
   lifecycle {
     ignore_changes = [
       records,
+      zone_id,
     ]
   }
 }
@@ -63,6 +64,7 @@ resource "aws_route53_record" "ipv6" {
   lifecycle {
     ignore_changes = [
       records,
+      zone_id,
     ]
   }
 }

--- a/modules/network_load_balancer/main.tf
+++ b/modules/network_load_balancer/main.tf
@@ -110,6 +110,11 @@ resource "aws_lb" "new" {
   tags = {
     Name = local.name
   }
+  lifecycle {
+    ignore_changes = [
+      subnet_mapping,
+    ]
+  }
 }
 
 resource "aws_lb_target_group" "created" {


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
In dualstack provisioning perceived changes is causing resource recreate, which is breaking the provision.
This adds lifecycle ignore changes to prevent recreate.
Also added updating the release-please and aws-configure actions.

## Testing

<!--- Please describe how you verified this change or why testing isn't relevant. --->

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
