### PR TITLE
fix: Add some QOL changes

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -42,11 +42,11 @@ if ! which "$0" | grep -q nix; then
     git checkout flake.lock
   fi
 
-  echo 'Installing Nix Profile...'
-  if ! nf profile install . --profile "$profile"; then
-    echo 'Failed to install new Nix profile! Reverting to previous profile...'
+  echo 'Adding Nix Profile...'
+  if ! nf profile add . --profile "$profile"; then
+    echo 'Failed to add new Nix profile! Reverting to previous profile...'
     git checkout flake.lock
-    nf profile install . --profile "$profile"
+    nf profile add . --profile "$profile"
   fi
 
   nf profile list --profile "$profile"

--- a/.github/ISSUE_TEMPLATE/problem.md
+++ b/.github/ISSUE_TEMPLATE/problem.md
@@ -2,7 +2,6 @@
 name: Report a Problem
 about: Create a report to help us improve
 title: '[PROBLEM] '
-labels: 'internal/user'
 assignees: ''
 
 ---
@@ -10,14 +9,7 @@ assignees: ''
 ### Environment Information
 <!--Please add information on the same line in quotes. Eg. - Terraform version: "v1.13.0" -->
 - Terraform version:
-- Rancher2 Provider version:
-- Rancher version:
-- Operating System of the Rancher Node:
 - Operating System of the machine running Terraform:
-- Kubernetes Distro (k3s/rke2):
-- Kubernetes Version:
-- Infrastructure Provider (AWS/GCP/vSphere/etc):
-- What is the scope of the token given to the provider?
 
 ### Describe the Problem
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -2,7 +2,6 @@
 name: Ask a Question
 about: Need help finding something or making something work
 title: '[QUESTION] '
-labels: 'internal/user'
 assignees: ''
 
 ---

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,18 @@
 <!--- If there is no user issue related to this then you should remove the next line --->
 Addresses #
 
-<!--- Add labels (eg. release/v14) for each release branch to target --->
-<!--- Please don't manually add "internal" labels, those are for automation only --->
 
 ## Description
-
 <!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
 
-## Testing
 
+## Testing
 <!--- Please describe how you verified this change or why testing isn't relevant. --->
 
+
 <!--- Does this change alter an interface that users of the provider will need to adjust to? --->
-<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
+<!--- Will there be any existing configurations broken by this change? --->
+<!--- If so, change the following line with an explanation. --->
+<!--- Breaking changes should be indicated in the commit message with an !, eg. fix!: or feat!: --->
+
 Not a breaking change.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,9 @@ env:
   AWS_ROLE: arn:aws:iam::270074865685:role/terraform-module-ci-test
   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
   ACME_SERVER_URL: https://acme-v02.api.letsencrypt.org/directory
-  NIX_INSTALL_SHA: de490f61fcbaf9a5cabf2fa621ddb9ef93ad35d9a23a04e7d51b26e092b63691
-  NIX_INSTALL_VERSION: 2.34.4
+  # https://releases.nixos.org/?prefix=nix
+  NIX_INSTALL_SHA: e9d447ce3d2ff62d7ff9cb6ef401de6fa8acb148839dd00f7271945d7b638b14
+  NIX_INSTALL_VERSION: 2.34.7
 
 permissions: write-all
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           release-type: terraform-module
       # https://github.com/actions/github-script
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v8.0.0
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         if: steps.release-please.outputs.pr
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -78,7 +78,7 @@ jobs:
         run: |
           ./run_tests.sh
       # https://github.com/actions/github-script
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v8.0.0
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         if: steps.release-please.outputs.pr
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -8,8 +8,9 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_OWNER: ${{ github.repository_owner }}
-  NIX_INSTALL_SHA: de490f61fcbaf9a5cabf2fa621ddb9ef93ad35d9a23a04e7d51b26e092b63691
-  NIX_INSTALL_VERSION: 2.34.4
+  # https://releases.nixos.org/?prefix=nix
+  NIX_INSTALL_SHA: e9d447ce3d2ff62d7ff9cb6ef401de6fa8acb148839dd00f7271945d7b638b14
+  NIX_INSTALL_VERSION: 2.34.7
 
 jobs:
   terraform:

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+
+# This script is run by the run_tests.sh script to clean up AWS resources created during testing.
+# It can also be run independently to clean up resources by providing a cleanup ID.
+cleanup_id="$1"
+if [ -z "$cleanup_id" ]; then
+  echo "No cleanup Id provided. Exiting."
+  exit 1
+fi
+echo "Starting cleanup for Id: $cleanup_id"
+IDENTIFIER="$cleanup_id"
+AWS_REGION="${AWS_REGION:-us-west-2}"
+
+resources_to_clear="$(leftovers -d --iaas=aws --aws-region="$AWS_REGION" --filter="Id:$IDENTIFIER" | grep -v 'AccessDenied')"
+resources_ids="$(echo "$resources_to_clear" | awk -F"Id:" '{print $2}' | awk -F"," '{print $1}' | awk -F")" '{print $1}' | sort | uniq)"
+max_attempts=3
+
+echo "   resources found:"
+while IFS= read -r r; do
+  echo "    $r"
+done <<<"$resources_to_clear"
+
+echo "   resources ids:"
+for r in $resources_ids; do
+  echo "    $r"
+done
+
+if [ -z "$resources_ids" ]; then resources_ids=$IDENTIFIER; fi
+
+for id in $resources_ids; do
+  IDENTIFIER=$id
+  echo "Clearing leftovers with Id $IDENTIFIER in $AWS_REGION..."
+  attempts=0
+
+  resources_to_clear="$(leftovers -d --iaas=aws --aws-region="$AWS_REGION" --filter="Id:$IDENTIFIER" | grep -v 'AccessDenied' || true)"
+  while [ -n "$resources_to_clear" ] && [ $attempts -lt $max_attempts ]; do
+    echo -e "found these resources to clear:\n $resources_to_clear\n"
+    leftovers --iaas=aws --aws-region="$AWS_REGION" --filter="Id:$IDENTIFIER" --no-confirm | grep -v 'AccessDenied' || true
+    sleep 10
+    resources_to_clear="$(leftovers -d --iaas=aws --aws-region="$AWS_REGION" --filter="Id:$IDENTIFIER" | grep -v 'AccessDenied' || true)"
+    if [ -n "$resources_to_clear" ]; then
+      echo "Some resources failed to clear, retrying in $((attempts * 10)) seconds..."
+    fi
+    sleep $((attempts * 10))
+    attempts=$((attempts + 1))
+  done
+
+  if [ $attempts -eq $max_attempts ]; then
+    echo "Warning: Failed to clear all resources after $max_attempts attempts."
+  fi
+
+  # remove secrets
+  echo "Clearing out secrets if they were missed..."
+  attempts=0
+  while [ $attempts -lt $max_attempts ]; do
+    while read -r arn; do
+      if [ -z "$arn" ]; then
+        continue
+      fi
+      echo "removing secret $arn..."
+      aws secretsmanager delete-secret --secret-id "$arn" --force-delete-without-recovery
+    done <<<"$(aws resourcegroupstaggingapi get-resources --no-cli-pager --resource-type-filters "secretsmanager:secret" --tag-filters "Key=Id,Values=$IDENTIFIER" | jq -r '.ResourceTagMappingList[]?.ResourceARN')"
+    sleep $((attempts * 10))
+    attempts=$((attempts + 1))
+  done
+
+  # remove s3 storage
+  echo "Clearing out s3 buckets if they were missed..."
+  attempts=0
+  while [ $attempts -lt $max_attempts ]; do
+    while read -r id; do
+      if [ -z "$id" ]; then
+        continue
+      fi
+      echo "   removing s3 bucket $id..."
+      echo "   clearing out versions..."
+      while read -r v; do
+        if [ -z "$v" ]; then continue; fi;
+        aws s3api delete-object --bucket "$id" --key "tfstate" --version-id="$v" > /dev/null 2>&1;
+      done <<<"$(aws s3api list-object-versions --bucket "$id" | jq -r '.DeleteMarkers[]?.VersionId' || true)"
+      while read -r v; do
+        if [ -z "$v" ]; then continue; fi;
+        aws s3api delete-object --bucket "$id" --key "tfstate" --version-id="$v" > /dev/null 2>&1;
+      done <<<"$(aws s3api list-object-versions --bucket "$id" | jq -r '.Versions[]?.VersionId' || true)"
+      echo "   removing bucket..."
+      aws s3 rb "s3://$id" --force
+    done <<<"$(aws resourcegroupstaggingapi get-resources --no-cli-pager --resource-type-filters "s3:bucket" --tag-filters "Key=Id,Values=$IDENTIFIER" | jq -r '.ResourceTagMappingList[]?.ResourceARN' | awk -F'arn:aws:s3:::' '{print $2}' || true)"
+    sleep $((attempts * 10))
+    attempts=$((attempts + 1))
+  done
+
+  # remove key pairs
+  echo "Clearing out key pairs if they were missed..."
+  attempts=0
+  while [ $attempts -lt $max_attempts ]; do
+    while read -r id; do
+      if [ -z "$id" ]; then
+        continue
+      fi
+      echo "   removing ec2 key pair $id..."
+      aws ec2 delete-key-pair --key-pair-id "$id" || true
+    done <<<"$(aws resourcegroupstaggingapi get-resources --no-cli-pager --resource-type-filters "ec2:key-pair" --tag-filters "Key=Id,Values=$IDENTIFIER" | jq -r '.ResourceTagMappingList[]?.ResourceARN' | awk -F'/' '{print $2}')"
+    sleep $((attempts * 10))
+    attempts=$((attempts + 1))
+  done
+
+  # remove server certificates
+  # unfortunately get-resources doesn't support iam server certificates
+  echo "Clearing out server certificates if they were missed..."
+  attempts=0
+  while [ $attempts -lt $max_attempts ]; do
+    while read -r name; do
+      if [ -z "$name" ]; then
+        continue
+      fi
+      if aws iam list-server-certificate-tags --server-certificate-name "$name" | jq -e --arg ID "$IDENTIFIER" '.Tags[] | select(.Key=="Id" and (.Value | contains($ID)))' > /dev/null; then
+        echo "   removing iam server certificate $name..."
+        aws iam delete-server-certificate --server-certificate-name "$name" || true
+      fi
+    done <<<"$(aws iam list-server-certificates | jq -r '.ServerCertificateMetadataList[].ServerCertificateName')"
+    sleep $((attempts * 10))
+    attempts=$((attempts + 1))
+  done
+
+  # remove load balancer target groups
+  echo "Clearing out load balancer target groups if they were missed..."
+  attempts=0
+  while [ $attempts -lt $max_attempts ]; do
+    while read -r arn; do
+      if [ -z "$arn" ]; then
+        continue
+      fi
+      echo "   removing load balancer target group $arn..."
+      aws elbv2 delete-target-group --target-group-arn "$arn" || true;
+    done <<<"$(aws resourcegroupstaggingapi get-resources --no-cli-pager --resource-type-filters "elasticloadbalancing:targetgroup" --tag-filters "Key=Id,Values=$IDENTIFIER" | jq -r '.ResourceTagMappingList[]?.ResourceARN')"
+    sleep $((attempts * 10))
+    attempts=$((attempts + 1))
+  done
+done
+
+echo "Cleanup completed."
+
+# These examples find Ids that need to be cleaned up by looking for resources owned by CI and extracting their Id tags.
+# This is useful if you happen to come across leftover resources and want to clean up anything that might have been missed with their specific Id.
+# For example, if you hit a quota limit and notice there a bunch of leftover secrets or target groups, you can run these commands to clean up all resources with the same Id as the leftover resources.
+# for id in $(aws resourcegroupstaggingapi get-resources --no-cli-pager --resource-type-filters "elasticloadbalancing:targetgroup" --tag-filters "Key=Owner,Values=terraform-ci@suse.com" | jq -r '.ResourceTagMappingList[]?.Tags[] | select(.Key=="Id") | .Value'); do ./cleanup.sh "$id"; done
+# for id in $(aws resourcegroupstaggingapi get-resources --no-cli-pager --resource-type-filters "secretsmanager:secret" --tag-filters "Key=Owner,Values=terraform-ci@suse.com" | jq -r '.ResourceTagMappingList[]?.Tags[] | select(.Key=="Id") | .Value'); do ./cleanup.sh "$id"; done
+# for id in $(for name in $(aws iam list-server-certificates | jq -r '.ServerCertificateMetadataList[].ServerCertificateName'); do echo "$(aws iam list-server-certificate-tags --server-certificate-name "$name" | jq -r '.Tags[] | select(.Key=="Id").Value')"; done); do ./cleanup.sh "$id"; done

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -136,7 +136,7 @@ for id in $resources_ids; do
     sleep $((attempts * 10))
     attempts=$((attempts + 1))
   done
-done
+
   # remove route 53 records
   echo "Clearing out Route 53 records if they were missed..."
   LOWER_IDENTIFIER=$(echo "$IDENTIFIER" | tr '[:upper:]' '[:lower:]')

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -137,6 +137,30 @@ for id in $resources_ids; do
     attempts=$((attempts + 1))
   done
 done
+  # remove route 53 records
+  echo "Clearing out Route 53 records if they were missed..."
+  LOWER_IDENTIFIER=$(echo "$IDENTIFIER" | tr '[:upper:]' '[:lower:]')
+  attempts=0
+  while [ $attempts -lt $max_attempts ]; do
+    while read -r hz; do
+      if [ -z "$hz" ]; then
+        continue
+      fi
+      while read -r record; do
+        if [ -z "$record" ]; then
+          continue
+        fi
+        record_name=$(echo "$record" | jq -r '.Name')
+        record_type=$(echo "$record" | jq -r '.Type')
+        echo "   removing route 53 record $record_name of type $record_type from zone $hz..."
+        change_batch=$(jq -n --argjson rec "$record" '{"Changes": [{"Action": "DELETE", "ResourceRecordSet": $rec}]}')
+        aws route53 change-resource-record-sets --hosted-zone-id "$hz" --change-batch "$change_batch" > /dev/null 2>&1 || true
+      done <<<"$(aws route53 list-resource-record-sets --hosted-zone-id "$hz" | jq -c --arg ID "$LOWER_IDENTIFIER" '.ResourceRecordSets[]? | select(.Name | contains($ID))')"
+    done <<<"$(aws route53 list-hosted-zones | jq -r '.HostedZones[]?.Id')"
+    sleep $((attempts * 10))
+    attempts=$((attempts + 1))
+  done
+done
 
 echo "Cleanup completed."
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -13,9 +13,9 @@ provider "acme" {
 locals {
   identifier   = var.identifier
   example      = "basic"
-  project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}-${local.identifier}", 0, 25))
+  project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}", 0, 15))
   zone         = var.zone
-  domain       = "${local.project_name}.${local.zone}"
+  domain       = "${local.project_name}-${local.identifier}.${local.zone}"
 }
 
 # AWS reserves the first four IP addresses and the last IP address in any CIDR block for its own use (cumulatively)

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -14,8 +14,8 @@ locals {
   identifier   = var.identifier
   example      = "basic"
   project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}", 0, 15))
-  zone         = var.zone
-  domain       = "${local.project_name}-${local.identifier}.${local.zone}"
+  zone         = lower(var.zone)
+  domain       = lower("${local.project_name}-${local.identifier}.${local.zone}")
 }
 
 # AWS reserves the first four IP addresses and the last IP address in any CIDR block for its own use (cumulatively)

--- a/examples/cert/main.tf
+++ b/examples/cert/main.tf
@@ -16,7 +16,7 @@ locals {
   project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}", 0, 15))
   owner        = "terraform-ci@suse.com"
   zone         = var.zone
-  domain       = "${local.project_name}-${local.identifier}.${local.zone}"
+  domain       = lower("${local.project_name}-${local.identifier}.${local.zone}")
 }
 
 # AWS reserves the first four IP addresses and the last IP address in any CIDR block for its own use (cumulatively)

--- a/examples/cert/main.tf
+++ b/examples/cert/main.tf
@@ -13,10 +13,10 @@ provider "acme" {
 locals {
   identifier   = var.identifier
   example      = "cert"
-  project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}-${local.identifier}", 0, 25))
+  project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}", 0, 15))
   owner        = "terraform-ci@suse.com"
   zone         = var.zone
-  domain       = "${local.project_name}.${local.zone}"
+  domain       = "${local.project_name}-${local.identifier}.${local.zone}"
 }
 
 # AWS reserves the first four IP addresses and the last IP address in any CIDR block for its own use (cumulatively)

--- a/examples/domain/main.tf
+++ b/examples/domain/main.tf
@@ -13,10 +13,10 @@ provider "acme" {
 locals {
   identifier   = var.identifier
   example      = "domain"
-  project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}-${local.identifier}", 0, 25))
+  project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}", 0, 15))
   owner        = "terraform-ci@suse.com"
   zone         = var.zone
-  domain       = "${local.project_name}.${local.zone}"
+  domain       = "${local.project_name}-${local.identifier}.${local.zone}"
 }
 
 # AWS reserves the first four IP addresses and the last IP address in any CIDR block for its own use (cumulatively)

--- a/examples/domain/main.tf
+++ b/examples/domain/main.tf
@@ -16,7 +16,7 @@ locals {
   project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}", 0, 15))
   owner        = "terraform-ci@suse.com"
   zone         = var.zone
-  domain       = "${local.project_name}-${local.identifier}.${local.zone}"
+  domain       = lower("${local.project_name}-${local.identifier}.${local.zone}")
 }
 
 # AWS reserves the first four IP addresses and the last IP address in any CIDR block for its own use (cumulatively)

--- a/examples/dualstack/main.tf
+++ b/examples/dualstack/main.tf
@@ -15,7 +15,7 @@ locals {
   example      = "dualstack"
   project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}", 0, 15))
   zone         = var.zone
-  domain       = "${local.project_name}-${local.identifier}.${local.zone}"
+  domain       = lower("${local.project_name}-${local.identifier}.${local.zone}")
 }
 
 # AWS reserves the first four IP addresses and the last IP address in any CIDR block for its own use (cumulatively)

--- a/examples/dualstack/main.tf
+++ b/examples/dualstack/main.tf
@@ -13,9 +13,9 @@ provider "acme" {
 locals {
   identifier   = var.identifier
   example      = "dualstack"
-  project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}-${local.identifier}", 0, 25))
+  project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}", 0, 15))
   zone         = var.zone
-  domain       = "${local.project_name}.${local.zone}"
+  domain       = "${local.project_name}-${local.identifier}.${local.zone}"
 }
 
 # AWS reserves the first four IP addresses and the last IP address in any CIDR block for its own use (cumulatively)

--- a/examples/ingress/main.tf
+++ b/examples/ingress/main.tf
@@ -14,9 +14,9 @@ provider "acme" {
 locals {
   identifier   = var.identifier
   example      = "ingress"
-  project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}-${local.identifier}", 0, 25))
+  project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}", 0, 15))
   zone         = var.zone
-  domain       = "${local.project_name}.${local.zone}"
+  domain       = "${local.project_name}-${local.identifier}.${local.zone}"
 }
 
 # AWS reserves the first four IP addresses and the last IP address in any CIDR block for its own use (cumulatively)

--- a/examples/ingress/main.tf
+++ b/examples/ingress/main.tf
@@ -16,7 +16,7 @@ locals {
   example      = "ingress"
   project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}", 0, 15))
   zone         = var.zone
-  domain       = "${local.project_name}-${local.identifier}.${local.zone}"
+  domain       = lower("${local.project_name}-${local.identifier}.${local.zone}")
 }
 
 # AWS reserves the first four IP addresses and the last IP address in any CIDR block for its own use (cumulatively)

--- a/examples/ipv6/main.tf
+++ b/examples/ipv6/main.tf
@@ -13,9 +13,9 @@ provider "acme" {
 locals {
   identifier   = var.identifier
   example      = "ipv6"
-  project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}-${local.identifier}", 0, 25))
+  project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}", 0, 15))
   zone         = var.zone
-  domain       = "${local.project_name}.${local.zone}"
+  domain       = "${local.project_name}-${local.identifier}.${local.zone}"
 }
 
 # AWS reserves the first four IP addresses and the last IP address in any CIDR block for its own use (cumulatively)

--- a/examples/ipv6/main.tf
+++ b/examples/ipv6/main.tf
@@ -15,7 +15,7 @@ locals {
   example      = "ipv6"
   project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}", 0, 15))
   zone         = var.zone
-  domain       = "${local.project_name}-${local.identifier}.${local.zone}"
+  domain       = lower("${local.project_name}-${local.identifier}.${local.zone}")
 }
 
 # AWS reserves the first four IP addresses and the last IP address in any CIDR block for its own use (cumulatively)

--- a/examples/selectsubnets/main.tf
+++ b/examples/selectsubnets/main.tf
@@ -15,7 +15,7 @@ locals {
   example      = "selectsubnets"
   project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}", 0, 15))
   zone         = var.zone
-  domain       = "${local.project_name}-${local.identifier}.${local.zone}"
+  domain       = lower("${local.project_name}-${local.identifier}.${local.zone}")
 }
 
 module "setup" {

--- a/examples/selectsubnets/main.tf
+++ b/examples/selectsubnets/main.tf
@@ -13,9 +13,9 @@ provider "acme" {
 locals {
   identifier   = var.identifier
   example      = "selectsubnets"
-  project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}-${local.identifier}", 0, 25))
+  project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}", 0, 15))
   zone         = var.zone
-  domain       = "${local.project_name}.${local.zone}"
+  domain       = "${local.project_name}-${local.identifier}.${local.zone}"
 }
 
 module "setup" {

--- a/examples/selectvpc/main.tf
+++ b/examples/selectvpc/main.tf
@@ -14,9 +14,9 @@ provider "acme" {
 locals {
   identifier   = var.identifier
   example      = "selectvpc"
-  project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}-${local.identifier}", 0, 25))
+  project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}", 0, 15))
   zone         = var.zone
-  domain       = "${local.project_name}.${local.zone}"
+  domain       = "${local.project_name}-${local.identifier}.${local.zone}"
 }
 
 module "setup" {

--- a/examples/selectvpc/main.tf
+++ b/examples/selectvpc/main.tf
@@ -16,7 +16,7 @@ locals {
   example      = "selectvpc"
   project_name = lower(substr("tf-${substr(md5(join("-", [local.example, md5(local.identifier)])), 0, 5)}", 0, 15))
   zone         = var.zone
-  domain       = "${local.project_name}-${local.identifier}.${local.zone}"
+  domain       = lower("${local.project_name}-${local.identifier}.${local.zone}")
 }
 
 module "setup" {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778458615,
-        "narHash": "sha256-cY07EsdhBJ8tFXPzDYevgqxRev9ZLxFonuq9wmq5kwg=",
+        "lastModified": 1778580735,
+        "narHash": "sha256-t+8AVV8ExvOmslz2sLIgw/hJBKlyl65rJvxjvvjHgpE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c6e5ca3c836a5f4dd9af9f2c1fc1c38f0fac988a",
+        "rev": "48d91f2c0ce7b9e589f967d4f685153dd765dcdd",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778580735,
-        "narHash": "sha256-t+8AVV8ExvOmslz2sLIgw/hJBKlyl65rJvxjvvjHgpE=",
+        "lastModified": 1778794387,
+        "narHash": "sha256-BL04pOS9453Awkeb9f90XBJXBSkWxN+vB7HIgnL0iMM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48d91f2c0ce7b9e589f967d4f685153dd765dcdd",
+        "rev": "8a1b0127302ea51e05bf4ea5a291743fac442406",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -85,10 +85,15 @@
 
           devShellPackage = pkgs.symlinkJoin {
             name = "dev-shell-package";
-            paths = with pkgs; [
+            paths = [
+              # place our downloaded packages here
+              aspellWithDicts
+              leftovers
+              terraform
+            ] ++ (with pkgs; [
+              # here are the packages from the nix repository
               actionlint
               age
-              aspellWithDicts
               awscli2
               bashInteractive
               curl
@@ -104,20 +109,18 @@
               gotestfmt
               gotestsum
               jq
-              leftovers
               less
               openssh
               openssl
               shellcheck
-              terraform
               tflint
               tfsec
               trivy
               updatecli
               vim
               which
-              yq
-            ];
+              yq-go
+            ]);
           };
         in
         {
@@ -126,7 +129,7 @@
           devShells.default = pkgs.mkShell {
             buildInputs = [ devShellPackage ];
             shellHook = ''
-              while read word; do echo -e "*$word\n#" | aspell -a --dont-validate-words >/dev/null; done < aspell_custom.txt
+              while read word; do echo -e "*$word\n#" | aspell -a --dont-validate-words 2&>/dev/null; done < aspell_custom.txt
               export PS1="nix:# ";
             '';
           };

--- a/flake.nix
+++ b/flake.nix
@@ -83,45 +83,54 @@
           };
           aspellWithDicts = pkgs.aspellWithDicts (d: [d.en d.en-computers]);
 
-          devShellPackage = pkgs.symlinkJoin {
-            name = "dev-shell-package";
-            paths = [
-              # place our downloaded packages here
-              aspellWithDicts
-              leftovers
-              terraform
-            ] ++ (with pkgs; [
-              # here are the packages from the nix repository
-              actionlint
-              age
-              awscli2
-              bashInteractive
-              curl
-              dig
-              eslint
-              gh
-              git
-              gitleaks
-              gnupg
-              go
-              golangci-lint
-              goreleaser
-              gotestfmt
-              gotestsum
-              jq
-              less
-              openssh
-              openssl
-              shellcheck
-              tflint
-              tfsec
-              trivy
-              updatecli
-              vim
-              which
-              yq-go
-            ]);
-          };
+        devPackages = [
+          # place our downloaded packages here
+          aspellWithDicts
+          leftovers
+          terraform
+        ] ++ (with pkgs; [
+          # here are the packages from the nix repository
+          actionlint
+          age
+          awscli2
+          bashInteractive
+          curl
+          dig
+          eslint
+          gh
+          git
+          gitleaks
+          gnupg
+          go
+          golangci-lint
+          goreleaser
+          gotestfmt
+          gotestsum
+          jq
+          less
+          openssh
+          openssl
+          shellcheck
+          tflint
+          tfsec
+          trivy
+          updatecli
+          vim
+          which
+          yq-go
+        ]);
+
+        devShellPackage = pkgs.symlinkJoin {
+          name = "dev-shell-package";
+
+          # buildEnv properly handles combining all outputs (like bin, out, etc.)
+          paths = [
+            (pkgs.buildEnv {
+              name = "dev-shell-env";
+              paths = devPackages;
+            })
+          ];
+        };
         in
         {
           packages.default = devShellPackage;

--- a/main.tf
+++ b/main.tf
@@ -140,6 +140,30 @@ resource "terraform_data" "input_validation" {
       ) ? false : true # the bad condition is defined, then the result is flipped to trigger the error
       error_message = "Even when skipping domain creation, the domain zone must still be set."
     }
+    precondition {
+      condition = (
+        local.domain_mod == 1 &&
+        local.domain_use_strategy != "skip" &&
+        length(local.domain) < 1
+      )
+      error_message = "If deploying a domain, a domain name must be set."
+    }
+    precondition {
+      condition = (
+        local.domain_mod == 1 &&
+        local.domain_use_strategy != "skip" &&
+        local.domain != lower(local.domain)
+      )
+      error_message = "If deploying a domain, a domain name must be lower case."
+    }
+    precondition {
+      condition = (
+        local.domain_mod == 1 &&
+        local.domain_use_strategy != "skip" &&
+        local.zone != lower(local.zone)
+      )
+      error_message = "If deploying a domain, a domain zone must be lower case."
+    }
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -54,27 +54,6 @@ locals {
   vpc_ipv4 = (local.vpc_mod > 0 ? module.vpc[0].ipv4 : null)
   vpc_ipv6 = (local.vpc_mod > 0 ? module.vpc[0].ipv6 : null)
 
-  # tflint-ignore: terraform_unused_declarations
-  fail_ipv6_missing = (
-    (
-      local.vpc_mod == 1 &&
-      (local.vpc_type == "ipv6" || local.vpc_type == "dualstack") &&
-      local.vpc_ipv6 == ""
-    ) ?
-    one([local.vpc_ipv6, "missing_ipv6_address"]) :
-    false
-  )
-  # tflint-ignore: terraform_unused_declarations
-  fail_ipv4_missing = (
-    (
-      local.vpc_mod == 1 &&
-      local.vpc_ipv4 == ""
-    ) ?
-    one([local.vpc_ipv4, "missing_ipv4_address"]) :
-    false
-  )
-
-
   # subnet
   subnet_names = var.subnet_names
   subnet_map = (length(local.subnet_names) > 0 ?
@@ -95,13 +74,6 @@ locals {
       }
     }
   )
-  # tflint-ignore: terraform_unused_declarations
-  fail_subnet_map_length = ((local.subnet_mod == 1 && local.subnet_use_strategy == "create" && (length(local.subnet_map) != length(local.availability_zones))) ? one([jsonencode(local.subnet_names), "length_subnet_names_must_match_availability_zones"]) : false)
-  # tflint-ignore: terraform_unused_declarations
-  fail_subnet_map_empty = ((local.subnet_mod == 1 && local.subnet_use_strategy == "create" && (length(local.subnet_map) < 1)) ? one([jsonencode(local.subnet_map), "subnet_map_empty"]) : false)
-  # tflint-ignore: terraform_unused_declarations
-  fail_subnets_not_created = ((local.subnet_mod == 1 && length(module.subnet) < 1) ? one([local.subnet_mod, "subnets_not_created"]) : false)
-
 
   # security group
   security_group_name = var.security_group_name
@@ -115,8 +87,60 @@ locals {
   domain            = var.domain
   cert_use_strategy = var.cert_use_strategy
   domain_zone       = var.domain_zone
-  # tflint-ignore: terraform_unused_declarations
-  fail_domain_zone = ((local.domain_mod == 1 && local.domain_use_strategy != "skip" && local.domain_zone == "") ? one([local.domain_zone, "domain_zone_missing"]) : false)
+}
+resource "terraform_data" "input_validation" {
+  lifecycle {
+    # precondition {
+    #   condition = "if true, ignore, if false, fail with below error message"
+    #   error_message = "The local variable isn't correct for some reason, please fix."
+    # }
+    precondition {
+      condition = (
+        local.vpc_mod == 1 &&
+        (local.vpc_type == "ipv6" || local.vpc_type == "dualstack") &&
+        local.vpc_ipv6 == ""
+      ) ? false : true # the bad condition is defined, then the result is flipped to trigger the error
+      error_message = "When deploying an IPv6 or Dualstack project, vpc_ipv6 must be set."
+    }
+    precondition {
+      condition = (
+        local.vpc_mod == 1 &&
+        local.vpc_ipv4 == ""
+      ) ? false : true # the bad condition is defined, then the result is flipped to trigger the error
+      error_message = "When deploying a project, vpc_ipv4 must be set."
+    }
+    precondition {
+      condition = (
+        local.subnet_mod == 1 &&
+        local.subnet_use_strategy == "create" &&
+        length(local.subnet_map) != length(local.availability_zones)
+      ) ? false : true # the bad condition is defined, then the result is flipped to trigger the error
+      error_message = "When creating subnets, the number of subnets to create must match the number of availability zones."
+    }
+    precondition {
+      condition = (
+        local.subnet_mod == 1 &&
+        local.subnet_use_strategy == "create" &&
+        length(local.subnet_map) < 1
+      )
+      error_message = "When creating subnets, at least one subnet must be created. Make sure you are in the correct region and that you are able to use all availablilty zones."
+    }
+    precondition {
+      condition = (
+        local.subnet_mod == 1 &&
+        length(module.subnet) < 1
+      ) ? false : true # the bad condition is defined, then the result is flipped to trigger the error
+      error_message = "When creating subnets, the subnet module should have count=1."
+    }
+    precondition {
+      condition = (
+        local.domain_mod == 1 &&
+        local.domain_use_strategy != "skip" &&
+        local.domain_zone == ""
+      ) ? false : true # the bad condition is defined, then the result is flipped to trigger the error
+      error_message = "Even when skipping domain creation, the domain zone must still be set."
+    }
+  }
 }
 
 data "aws_availability_zones" "available" {
@@ -124,6 +148,9 @@ data "aws_availability_zones" "available" {
 }
 
 module "vpc" {
+  depends_on = [
+    terraform_data.input_validation,
+  ]
   count  = local.vpc_mod
   source = "./modules/vpc"
   use    = local.vpc_use_strategy
@@ -133,6 +160,7 @@ module "vpc" {
 
 module "subnet" {
   depends_on = [
+    terraform_data.input_validation,
     module.vpc,
   ]
   for_each          = (local.subnet_mod == 1 ? local.subnet_map : tomap({}))
@@ -149,8 +177,9 @@ module "subnet" {
 
 module "project_security_group" {
   depends_on = [
-    module.subnet,
+    terraform_data.input_validation,
     module.vpc,
+    module.subnet,
   ]
   count    = local.security_group_mod
   source   = "./modules/security_group"
@@ -167,6 +196,7 @@ module "project_security_group" {
 
 module "network_load_balancer" {
   depends_on = [
+    terraform_data.input_validation,
     module.vpc,
     module.subnet,
     module.project_security_group,
@@ -184,6 +214,7 @@ module "network_load_balancer" {
 
 module "domain" {
   depends_on = [
+    terraform_data.input_validation,
     module.vpc,
     module.subnet,
     module.project_security_group,

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -4,22 +4,70 @@ rerun_failed=false
 specific_test=""
 specific_package=""
 cleanup_id=""
+slow_mode=false
+dirty_mode=false
 
-while getopts ":r:t:p:c:" opt; do
+while getopts ":rsdt:p:c:" opt; do
   case $opt in
     r) rerun_failed=true ;;
     t) specific_test="$OPTARG" ;;
     p) specific_package="$OPTARG" ;;
     c) cleanup_id="$OPTARG" ;;
+    d) dirty_mode=true ;;
+    s) slow_mode=true ;;
     \?) cat <<EOT >&2 && exit 1 ;;
 Invalid option -$OPTARG, valid options are
   -r to re-run failed tests
-  -t to specify a specific test (eg. TestBase)
-  -p to specify a specific test package (eg. base)
+  -s to run tests in slow mode (one at a time to avoid AWS rate limiting)
   -c to run clean up only with the given id (eg. abc123)
+  -d to skip cleanup (dirty mode)
+  -t to specify a specific test (eg. TestBase)
+  -p to specify a specific test package (eg. one)
+Only one of -c, -t, or -p can be used at a time.
 EOT
   esac
 done
+
+if [ $slow_mode == true ]; then
+  echo "Running in slow mode: tests will be run one at a time to avoid AWS rate limiting."
+elif [ $slow_mode == false ]; then
+  echo "Running in normal mode: tests will be run in parallel."
+fi
+if [ $rerun_failed == true ]; then
+  echo "Rerun failed tests is enabled."
+elif [ $rerun_failed == false ]; then
+  echo "Rerun failed tests is disabled."
+fi
+if [ -n "$specific_test" ]; then
+  echo "Specific test to run: $specific_test"
+else
+  echo "No specific test to run."
+fi
+if [ -n "$specific_package" ]; then
+  echo "Specific package to run: $specific_package"
+else
+  echo "No specific package to run."
+fi
+if [ -n "$cleanup_id" ]; then
+  echo "Cleanup only mode enabled with id: $cleanup_id"
+fi
+if [ -n "$cleanup_id" ] && { [ -n "$specific_test" ] || [ -n "$specific_package" ]; }; then
+  echo "Error: Only one of -c, -t, or -p can be used at a time." >&2
+  exit 1
+fi
+if [ -n "$specific_test" ] && { [ -n "$specific_package" ] || [ -n "$cleanup_id" ]; }; then
+  echo "Error: Only one of -c, -t, or -p can be used at a time." >&2
+  exit 1
+fi
+if [ -n "$specific_package" ] && { [ -n "$specific_test" ] || [ -n "$cleanup_id" ]; }; then
+  echo "Error: Only one of -c, -t, or -p can be used at a time." >&2
+  exit 1
+fi
+if [ $dirty_mode == true ]; then
+  echo "Running in dirty mode: skipping cleanup."
+elif [ $dirty_mode == false ]; then
+  echo "Running in normal mode: cleanup will try to remove all resources matching ID."
+fi
 
 # shellcheck disable=SC2143
 if [ -n "$cleanup_id" ]; then
@@ -28,8 +76,25 @@ fi
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
+# Find the tests directory
+TEST_DIR=""
+if [ -d "tests" ]; then
+  TEST_DIR="tests"
+fi
+if [ -d "test" ]; then
+  TEST_DIR="test"
+fi
+if [ -d "test/tests" ]; then
+  TEST_DIR="test/tests"
+fi
+if [ "$TEST_DIR" == "" ]; then
+  echo "Error: Unable to find tests directory" >&2
+  exit 1
+fi
+
 run_tests() {
   local rerun=$1
+  local slow_mode=$2
   REPO_ROOT="$(git rev-parse --show-toplevel)"
   cd "$REPO_ROOT" || exit 1
 
@@ -37,9 +102,14 @@ run_tests() {
   TEST_DIR=""
   if [ -d "tests" ]; then
     TEST_DIR="tests"
-  elif [ -d "test/tests" ]; then
+  fi
+  if [ -d "test" ]; then
+    TEST_DIR="test"
+  fi
+  if [ -d "test/tests" ]; then
     TEST_DIR="test/tests"
-  else
+  fi
+  if [ "$TEST_DIR" == "" ]; then
     echo "Error: Unable to find tests directory" >&2
     exit 1
   fi
@@ -85,6 +155,37 @@ EOF
   else
     package_pattern="..."
   fi
+
+  # We need both -p and -parallel, as -p sets the number of packages to test in parallel,
+  #  and -parallel sets the number of tests to run in parallel.
+  # By setting both to 1, we ensure that tests are run sequentially, which can help avoid AWS rate limiting issues.
+  # It does increase the runtime significantly though.
+  local parallel_packages=""
+  local parallel_tests=""
+  if [ "$slow_mode" = true ]; then
+    echo "Running in slow mode..."
+    parallel_packages="-p=1"
+    parallel_tests="-parallel=1"
+  fi
+
+  CMD=$(cat <<EOT
+gotestsum \
+  --format=standard-verbose \
+  --jsonfile "/tmp/${IDENTIFIER}_test.log" \
+  --post-run-command "sh /tmp/${IDENTIFIER}_test-processor" \
+  --packages "$REPO_ROOT/$TEST_DIR/$package_pattern" \
+  -- \
+  -count=1 \
+  -timeout=300m \
+  -failfast \
+  $parallel_packages \
+  $parallel_tests \
+  $rerun_flag \
+  $specific_test_flag
+EOT
+)
+  echo "Running command: $CMD"
+
   # shellcheck disable=SC2086
   gotestsum \
     --format=standard-verbose \
@@ -92,10 +193,11 @@ EOF
     --post-run-command "sh /tmp/${IDENTIFIER}_test-processor" \
     --packages "$REPO_ROOT/$TEST_DIR/$package_pattern" \
     -- \
-    -parallel=2 \
     -count=1 \
-    -failfast=1 \
     -timeout=300m \
+    -failfast \
+    $parallel_packages \
+    $parallel_tests \
     $rerun_flag \
     $specific_test_flag
 
@@ -111,20 +213,70 @@ if [ -z "$GITHUB_TOKEN" ]; then echo "GITHUB_TOKEN isn't set"; else echo "GITHUB
 if [ -z "$GITHUB_OWNER" ]; then echo "GITHUB_OWNER isn't set"; else echo "GITHUB_OWNER is set"; fi
 if [ -z "$ZONE" ]; then echo "ZONE isn't set"; else echo "ZONE is set"; fi
 
+cleanup_and_exit() {
+  local exit_code=$?
+  # Disable traps to prevent recursion
+  trap - EXIT INT TERM
+
+  if [ "$dirty_mode" = true ]; then
+    echo "Running in dirty mode, skipping cleanup..."
+  else
+    echo "Starting cleanup..."
+    sh "$REPO_ROOT/cleanup.sh" "$IDENTIFIER"
+    local c_code=$?
+    if [ $c_code -ne 0 ]; then
+      echo "Cleanup failed with exit code $c_code"
+      if [ $exit_code -eq 0 ]; then
+        exit_code=$c_code
+      fi
+    else
+      echo "Cleanup completed successfully."
+    fi
+  fi
+
+  if [ -n "$cleanup_id" ]; then
+    # cleanup only mode
+    exit $exit_code
+  fi
+
+  if [ -f "/tmp/${IDENTIFIER}_failed_tests.txt" ]; then
+    echo "done, test failed"
+    exit 1
+  else
+    if [ $exit_code -eq 0 ]; then
+      echo "done, test passed"
+    else
+      echo "done, script exited with error $exit_code"
+    fi
+    exit $exit_code
+  fi
+}
+
+trap cleanup_and_exit EXIT INT TERM
+
 if [ -z "$cleanup_id" ]; then
-  echo "checking tests for compile errors..."
+
   D="$(pwd)"
 
-  cd "$REPO_ROOT/test/tests" || exit
+  echo "tidying..."
+  cd "$REPO_ROOT/$TEST_DIR" || exit
   if ! go mod tidy; then C=$?; echo "failed to tidy, exit code $C"; exit $C; fi
-  echo "completed tidy..."
 
+  echo "formatting tests..."
+  gofmt -s -w -e .
+  echo "done formatting"
+
+  echo "checking tests for compile errors..."
   while IFS= read -r file; do
     echo "found $file";
     if ! go test -c "$file" -o "${file}.test"; then C=$?; echo "failed to compile $file, exit code $C"; exit $C; fi
     rm -rf "${file}.test"
-  done <<< "$(find "$REPO_ROOT/test" -not \( -path "$REPO_ROOT/test/tests/data" -prune \) -name '*.go')"
+  done <<< "$(find "$REPO_ROOT/$TEST_DIR" -not \( -path "$REPO_ROOT/$TEST_DIR/data" -prune \) -name '*.go')"
   echo "compile checks passed..."
+
+  echo "checking tests for go lint errors..."
+  if ! golangci-lint run; then echo "lint failed..."; exit 1; fi
+  echo "lint errors complete"
 
   cd "$D" || exit
 
@@ -132,98 +284,16 @@ if [ -z "$cleanup_id" ]; then
   if ! tflint --recursive; then C=$?; echo "tflint failed, exit code $C"; exit $C; fi
   echo "terraform configs valid..."
 
+  make build
+
   # Run tests initially
-  run_tests false
-  echo "waiting for 60 sec for deletes to propagate"
+  run_tests false "$slow_mode"
   sleep 60
 
   # Check if we need to rerun failed tests
   if [ "$rerun_failed" = true ] && [ -f "/tmp/${IDENTIFIER}_failed_tests.txt" ]; then
     echo "Rerunning failed tests..."
-    run_tests true
-    echo "waiting for 60 sec for deletes to propagate"
+    run_tests true "$slow_mode"
     sleep 60
   fi
-fi
-
-echo "Clearing leftovers with Id $IDENTIFIER in $AWS_REGION..."
-
-# shellcheck disable=SC2143
-if [ -n "$IDENTIFIER" ]; then
-  attempts=0
-  # shellcheck disable=SC2143
-  while [ -n "$(leftovers -d --iaas=aws --aws-region="$AWS_REGION" --filter="Id:$IDENTIFIER" | grep -v 'AccessDenied')" ] && [ $attempts -lt 3 ]; do
-    leftovers --iaas=aws --aws-region="$AWS_REGION" --filter="Id:$IDENTIFIER" --no-confirm | grep -v 'AccessDenied' || true
-    sleep 10
-    attempts=$((attempts + 1))
-  done
-
-  if [ $attempts -eq 3 ]; then
-    echo "Warning: Failed to clear all resources after 3 attempts."
-  fi
-
-  # remove key pairs
-  attempts=0
-  # shellcheck disable=SC2143
-  while [ -n "$(leftovers -d --iaas=aws --aws-region="$AWS_REGION" --type="ec2-key-pair" --filter="terraform-ci-$IDENTIFIER" | grep -v 'AccessDenied')" ] && [ $attempts -lt 3 ]; do
-    leftovers --iaas=aws --aws-region="$AWS_REGION" --type="ec2-key-pair" --filter="terraform-ci-$IDENTIFIER" --no-confirm | grep -v 'AccessDenied' || true
-    sleep 10
-    attempts=$((attempts + 1))
-  done
-
-  if [ $attempts -eq 3 ]; then
-    echo "Warning: Failed to clear all EC2 key pairs after 3 attempts."
-  fi
-
-  # remove s3 storage
-  attempts=0
-  ID="$(aws s3 ls | grep -i "$IDENTIFIER" | awk '{print $3}')"
-  # shellcheck disable=SC2143
-  while [ -n "$(aws s3 ls | grep -i "$IDENTIFIER")" ] && [ $attempts -lt 3 ]; do
-    echo "found s3 bucket $ID, removing..."
-    while read -r v; do
-      if [ -z "$v" ]; then continue; fi;
-      aws s3api delete-object --bucket "$(echo "$ID" | tr '[:upper:]' '[:lower:]')" --key "tfstate" --version-id="$v"
-    done <<<"$(
-      aws s3api list-object-versions --bucket "$(echo "$ID" | tr '[:upper:]' '[:lower:]')" | jq -r '.Versions[]?.VersionId'
-    )"
-
-    while read -r v; do
-      if [ -z "$v" ]; then continue; fi;
-      aws s3api delete-object --bucket "$(echo "$ID" | tr '[:upper:]' '[:lower:]')" --key "tfstate" --version-id="$v";
-    done <<<"$(
-      aws s3api list-object-versions --bucket "$(echo "$ID" | tr '[:upper:]' '[:lower:]')" | jq -r '.DeleteMarkers[]?.VersionId'
-    )"
-
-    aws s3api delete-bucket --bucket "$(echo "$ID" | tr '[:upper:]' '[:lower:]')"
-
-    sleep 10
-    attempts=$((attempts + 1))
-  done
-
-  # remove load balancer target groups
-  attempts=0
-  # shellcheck disable=SC2143
-  while [ $attempts -lt 3 ]; do
-    while read -r line; do
-      if [ -z "$line" ]; then continue; fi
-      echo "removing load balancer target group, $line..."
-      aws elbv2 delete-target-group --target-group-arn "$line";
-    done <<<"$(
-      while read -r line; do
-        if [ -z "$line" ]; then continue; fi
-        aws elbv2 describe-tags --resource-arns "$line" | jq -r --arg id "$IDENTIFIER" '.TagDescriptions[] | select(any(.Tags[]; .Key == "Id" and .Value == $id)) | .ResourceArn // ""';
-      done <<<"$(aws elbv2 describe-target-groups | jq -r '.TargetGroups[]?.TargetGroupArn')"
-    )"
-    sleep 10
-    attempts=$((attempts + 1))
-  done
-fi
-
-if [ -f "/tmp/${IDENTIFIER}_failed_tests.txt" ]; then
-  echo "done, test failed"
-  exit 1
-else
-  echo "done, test passed"
-  exit 0
 fi


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
Lots of small QOL changes:
- [x] investigate removing abspath calls if they break using states on different machines
- [x] update all "one" validations with terraform data resources with lifecycle preconditions
- [x] update all flakes to separate out downloaded derivations from std packages
- [x] update all flakes to download terraform
- [x] update all flakes to redirect `2&` for aspell to avoid nroff messages
- [x] update all .envrc file to use `add` instead of `install` for nix profiles
- [x] all modules need the cleanup script and it needs to be triggered with a trap
- [x] all cleanup scripts need to clean up domain names
- [x] all module examples to have the identifier in the domain name
- [x] update Nix in all workflows to v2.34.7
- [x] bump release please action to v5.0.0
- [x] bump github script to v9
- [x] bump helm provider to v3.1.1
- [x] fix supply chain vulnerability scan issues
- [x] inconsistent dependency file issues when running lots of tests at once

## Testing
actionlint for nix,
No new behavior was added, just a different (more official) way to get the same result, verified all tests still pass.

<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? If so, change the following line with an explanation. --->
Not a breaking change.
