### PR TITLE
fix: remove docker ecosystem from dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -18,11 +18,3 @@ updates:
       day: "sunday" # this way it is ready for review on Monday
     commit-message:
       prefix: "fix"
-  # Check for updates to CI container image every week
-  - package-ecosystem: "docker"
-    directory: "/.github/workflows"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-    commit-message:
-      prefix: "fix"


### PR DESCRIPTION
## Description
<!--- Describe your change and how it addresses the issue linked above or a problem with the product. --->
CI is failing for dependabot looking for Dockerfiles.
Since we don't have any docker files I am removing this ecosystem.
The original goal was to have dependabot update the container image for the workflow jobs, but it seems impossible.

## Testing
<!--- Please describe how you verified this change or why testing isn't relevant. --->


<!--- Does this change alter an interface that users of the provider will need to adjust to? --->
<!--- Will there be any existing configurations broken by this change? --->
<!--- If so, change the following line with an explanation. --->
<!--- Breaking changes should be indicated in the commit message with an !, eg. fix!: or feat!: --->

Not a breaking change.
